### PR TITLE
Isnestedprivate

### DIFF
--- a/Benday.SolutionUtil.Api/ClassDiagramCommand.cs
+++ b/Benday.SolutionUtil.Api/ClassDiagramCommand.cs
@@ -88,7 +88,7 @@ public class ClassDiagramCommand : SynchronousCommand
     protected override void OnExecute()
     {
         var filename = Arguments.GetPathToFile(Constants.ArgumentNameFilename, true);
-        
+
         filename = Path.GetFullPath(filename);
 
         var filterByNamespace = Arguments.GetStringValue(Constants.ArgumentsFilterByNamespace);
@@ -182,7 +182,7 @@ public class ClassDiagramCommand : SynchronousCommand
         {
             return false;
         }
-        
+
         if (string.IsNullOrWhiteSpace(type.Name) == true)
         {
             return false;
@@ -326,7 +326,7 @@ classDiagram
 
         WriteLine();
         WriteLine();
-        
+
         WriteLine($"Wrote class diagram to:");
         WriteLine(outputFilename);
     }
@@ -336,6 +336,16 @@ classDiagram
 
     private void AddTypeToDiagram(StringBuilder builder, Type type)
     {
+        var properties = type.GetProperties();
+        var methods = type.GetMethods();
+
+
+
+        if (HasDisplayableMethodsAndProperties(properties, methods) == false)
+        {
+            return;
+        }
+
         builder.AppendLine($"class {GetName(type)} {{");
 
         if (type.IsInterface == true)
@@ -347,14 +357,10 @@ classDiagram
             builder.AppendLine($"    {ABSTRACT_TAG}");
         }
 
-        var properties = type.GetProperties();
-
         foreach (var property in properties)
         {
             builder.AppendLine($"    +{GetName(property.PropertyType)} {property.Name}");
         }
-
-        var methods = type.GetMethods();
 
         foreach (var method in methods)
         {
@@ -380,6 +386,37 @@ classDiagram
 
         builder.AppendLine("}");
     }
+
+    private bool HasDisplayableMethodsAndProperties(PropertyInfo[] properties, MethodInfo[] methods)
+    {
+        if (properties.Length == 0 && methods.Length == 0)
+        {
+            return false;
+        }
+        else
+        {
+            bool hasDisplayable = false;
+
+            foreach (var method in methods)
+            {
+                if (IsPropertyMethod(method) == true)
+                {
+                    continue;
+                }
+
+                if (IsSystemObjectMethod(method) == true)
+                {
+                    continue;
+                }
+
+                hasDisplayable = true;
+                break;
+            }
+
+            return hasDisplayable;
+        }
+    }
+
 
     private string GetName(Type type)
     {

--- a/Benday.SolutionUtil.Api/ClassDiagramCommand.cs
+++ b/Benday.SolutionUtil.Api/ClassDiagramCommand.cs
@@ -493,8 +493,10 @@ classDiagram
     public const string ABSTRACT_TAG = @"&lt;&lt;abstract&gt;&gt;";
     public const string INTERFACE_TAG = @"&lt;&lt;interface&gt;&gt;";
 
-    private void AddTypeToDiagram(StringBuilder builder, Type type)
+    private void AddTypeToDiagram(StringBuilder document, Type type)
     {
+        
+
         var properties = type.GetProperties();
         var methods = type.GetMethods();
 
@@ -514,7 +516,14 @@ classDiagram
             return;
         }
 
-        builder.AppendLine($"class {className} {{");
+
+        var builder = new StringBuilder();
+
+        // I need to build the class diagram content before deciding what the 
+        // class diagram starting syntax should be.  That's why i'm not writing 
+        // this to the document yet.
+        //
+        // Deliberately not writing this line --> builder.AppendLine($"class {GetName(type)} {{");
 
         if (type.IsInterface == true)
         {
@@ -552,7 +561,18 @@ classDiagram
             }
         }
 
-        builder.AppendLine("}");
+        // add content to the diagram
+        if (builder.Length == 0)
+        {
+            document.AppendLine($"class {GetName(type)}");
+            document.AppendLine();
+        }
+        else
+        {
+            document.AppendLine($"class {GetName(type)} {{");
+            document.AppendLine(builder.ToString());
+            document.AppendLine("}");
+        }
     }
 
     private bool HasDisplayableMethodsAndProperties(PropertyInfo[] properties, MethodInfo[] methods)
@@ -598,7 +618,7 @@ classDiagram
 
             if (name.StartsWith("<") == true)
             {
-                var fullName = type.FullName;
+                var fullName = type.FullName ?? string.Empty;
 
                 // get everything after the last period
                 var lastPeriodIndex = fullName.LastIndexOf('.');

--- a/Benday.SolutionUtil.ConsoleUi/Benday.SolutionUtil.ConsoleUi.csproj
+++ b/Benday.SolutionUtil.ConsoleUi/Benday.SolutionUtil.ConsoleUi.csproj
@@ -17,9 +17,11 @@
     <PackageReadmeFile>README-for-nuget.md</PackageReadmeFile>
     <PackageIcon>bdc_mark_128_128.png</PackageIcon>
     <AssemblyVersion>2.15.0</AssemblyVersion>
-    <Version>2.15.0</Version>
+    <Version>2.16.0</Version>
     <Description>A collection of useful command line utilities for .NET Core Solutions &amp; Projects</Description>
     <PackageReleaseNotes>
+      v2.16 - Class diagram bug fix for empty classes.
+      v2.15 - Generate solutions and projects for .NET Core Console, Web, Web API, and .NET MAUI.
       v2.14 - Generate class diagrams for an assembly.
       v2.13 - Added xml formatter command that allows recursive file processing.
       v2.12 - Command to update or increment package version number and assembly version number.

--- a/Benday.SolutionUtil.ConsoleUi/Properties/launchSettings.json
+++ b/Benday.SolutionUtil.ConsoleUi/Properties/launchSettings.json
@@ -76,7 +76,7 @@
     },
     "classdiagram-cosmosdb": {
       "commandName": "Project",
-      "commandLineArgs": "classdiagram /Users/benday/code/benday-inc/Benday.CosmosDb/Benday.CosmosDb/bin/Debug/net8.0/Benday.CosmosDb.dll"
+      "commandLineArgs": "classdiagram C:\\code\\benday-inc\\Benday.CosmosDb\\Benday.CosmosDb\\bin\\Debug\\net8.0\\Benday.CosmosDb.dll"
     },
     "classdiagram-filter-by-typename-exact": {
       "commandName": "Project",

--- a/Benday.SolutionUtil.ConsoleUi/Properties/launchSettings.json
+++ b/Benday.SolutionUtil.ConsoleUi/Properties/launchSettings.json
@@ -74,6 +74,10 @@
       "commandName": "Project",
       "commandLineArgs": "classdiagram /Users/benday/code/benday-inc/XamlUtil/XamlUtil.ConsoleUi/bin/Debug/net8.0/Benday.CommandsFramework.dll"
     },
+    "classdiagram-cosmosdb": {
+      "commandName": "Project",
+      "commandLineArgs": "classdiagram /Users/benday/code/benday-inc/Benday.CosmosDb/Benday.CosmosDb/bin/Debug/net8.0/Benday.CosmosDb.dll"
+    },
     "classdiagram-filter-by-typename-exact": {
       "commandName": "Project",
       "commandLineArgs": "classdiagram /typenames:IOwnedItem,owneditembase /typenamesmatchexact /Users/benday/code/repos/PowerpointUtil/cross-platform/PowerpointUtil.Api/bin/Debug/net8.0/PowerpointUtil.Api.dll"


### PR DESCRIPTION
This pull request includes significant changes to the `Benday.SolutionUtil.Api/ClassDiagramCommand.cs` file to improve assembly type resolution and filtering logic, as well as a minor update to the `launchSettings.json` file.

### Improvements to assembly type resolution and filtering:

* Added logic to handle assembly resolution from the NuGet cache and local directories in the `GetTypesSafe` method. This includes the addition of a new method `TryToResolveDependency` to attempt resolving dependencies when loading types from assemblies. [[1]](diffhunk://#diff-7d95cd3412f7860e73817097e7737d17c98c06ed786eed1fbeecf8d4bc887d03R57-R88) [[2]](diffhunk://#diff-7d95cd3412f7860e73817097e7737d17c98c06ed786eed1fbeecf8d4bc887d03R117-R221)
* Enhanced the `MatchesFilter` method to provide detailed logging for types that are skipped due to various conditions, such as being non-public, nested private, or not matching namespace/type filters.
* Introduced the `HasDisplayableMethodsAndProperties` method to check if a type has displayable methods or properties before adding it to the diagram. This ensures only relevant types are included. [[1]](diffhunk://#diff-7d95cd3412f7860e73817097e7737d17c98c06ed786eed1fbeecf8d4bc887d03R500-R521) [[2]](diffhunk://#diff-7d95cd3412f7860e73817097e7737d17c98c06ed786eed1fbeecf8d4bc887d03L399-R635)

### Minor update to launch settings:

* Added a new profile `classdiagram-cosmosdb` to the `launchSettings.json` file for generating class diagrams for the `Benday.CosmosDb` project.